### PR TITLE
Feature/trip-search

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.security:spring-security-oauth2-client'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'org.springframework.data:spring-data-elasticsearch'
+	implementation group: 'com.google.maps', name: 'google-maps-services', version: '2.2.0'
+	implementation 'com.google.maps:google-maps-services:0.15.0'  // Google Places API 클라이언트
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/daehun/trip_java/Search/config/AppConfig.java
+++ b/src/main/java/daehun/trip_java/Search/config/AppConfig.java
@@ -1,0 +1,14 @@
+package daehun.trip_java.Search.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/daehun/trip_java/Search/controller/PlaceController.java
+++ b/src/main/java/daehun/trip_java/Search/controller/PlaceController.java
@@ -1,0 +1,42 @@
+package daehun.trip_java.Search.controller;
+
+import daehun.trip_java.Search.domain.Place;
+import daehun.trip_java.Search.service.PlaceDataService;
+import daehun.trip_java.Search.service.PlaceService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/places")
+public class PlaceController {
+
+  private final PlaceService placeService;
+  private final PlaceDataService placeDataService;
+
+  public PlaceController(PlaceService placeService, PlaceDataService placeDataService) {
+    this.placeService = placeService;
+    this.placeDataService = placeDataService;
+  }
+
+  // 기존 장소 이름으로 검색
+  @GetMapping("/{name}")
+  public Place getPlace(@PathVariable String name) {
+    return placeService.getPlaceByName(name);
+  }
+
+  // 반경 내 장소 검색
+  @GetMapping("/nearby")
+  public List<Place> getNearbyPlaces(@RequestParam double latitude, @RequestParam double longitude) {
+    return placeService.getNearbyPlaces(latitude, longitude);
+  }
+
+  @GetMapping("/api/collect-seoul-data")
+  public String collectSeoulData() {
+    placeDataService.saveTouristAttractions();
+    return "서울시 관광지 데이터가 수집되어 Elasticsearch에 저장되었습니다.";
+  }
+}

--- a/src/main/java/daehun/trip_java/Search/controller/PlaceController.java
+++ b/src/main/java/daehun/trip_java/Search/controller/PlaceController.java
@@ -6,6 +6,7 @@ import daehun.trip_java.Search.service.PlaceService;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,7 +35,7 @@ public class PlaceController {
     return placeService.getNearbyPlaces(latitude, longitude);
   }
 
-  @GetMapping("/api/collect-seoul-data")
+  @PostMapping("/api/collect-seoul-data")
   public String collectSeoulData() {
     placeDataService.saveTouristAttractions();
     return "서울시 관광지 데이터가 수집되어 Elasticsearch에 저장되었습니다.";

--- a/src/main/java/daehun/trip_java/Search/domain/Place.java
+++ b/src/main/java/daehun/trip_java/Search/domain/Place.java
@@ -1,6 +1,7 @@
 package daehun.trip_java.Search.domain;
 
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.elasticsearch.annotations.Document;
@@ -29,4 +30,7 @@ public class Place {
 
   @Field(type = FieldType.Double)
   private Float rating;
+
+  @Field(type = FieldType.Date)
+  private LocalDateTime updatedAt;
 }

--- a/src/main/java/daehun/trip_java/Search/domain/Place.java
+++ b/src/main/java/daehun/trip_java/Search/domain/Place.java
@@ -1,0 +1,32 @@
+package daehun.trip_java.Search.domain;
+
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Getter
+@Setter
+@Document(indexName = "place")
+public class Place {
+
+  @Id
+  private Long id;
+
+  @Field(type = FieldType.Text)
+  private String name;
+
+  @Field(type = FieldType.Text)
+  private String address;
+
+  @Field(type = FieldType.Double)
+  private Double latitude;
+
+  @Field(type = FieldType.Double)
+  private Double longitude;
+
+  @Field(type = FieldType.Double)
+  private Float rating;
+}

--- a/src/main/java/daehun/trip_java/Search/dto/TouristAttractionsResponse.java
+++ b/src/main/java/daehun/trip_java/Search/dto/TouristAttractionsResponse.java
@@ -1,0 +1,36 @@
+package daehun.trip_java.Search.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TouristAttractionsResponse {
+  @JsonProperty("TouristAttract1ionsInfo")
+  private TouristAttractionsInfo touristAttractionsInfo;
+
+  @Getter
+  @Setter
+  public static class TouristAttractionsInfo {
+    @JsonProperty("row")
+    private List<TouristAttraction> attractions;
+  }
+
+  @Getter
+  @Setter
+  public static class TouristAttraction {
+    @JsonProperty("POST_SJ")
+    private String name;
+
+    @JsonProperty("ADDRESS")
+    private String address;
+
+    @JsonProperty("Y")
+    private double latitude;
+
+    @JsonProperty("X")
+    private double longitude;
+  }
+}

--- a/src/main/java/daehun/trip_java/Search/repository/PlaceRepository.java
+++ b/src/main/java/daehun/trip_java/Search/repository/PlaceRepository.java
@@ -1,0 +1,8 @@
+package daehun.trip_java.Search.repository;
+import daehun.trip_java.Search.domain.Place;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import java.util.Optional;
+
+public interface PlaceRepository extends ElasticsearchRepository<Place, Long> {
+  Optional<Place> findByName(String name);
+}

--- a/src/main/java/daehun/trip_java/Search/service/GooglePlacesService.java
+++ b/src/main/java/daehun/trip_java/Search/service/GooglePlacesService.java
@@ -1,0 +1,43 @@
+package daehun.trip_java.Search.service;
+
+import com.google.maps.GeoApiContext;
+import com.google.maps.PlacesApi;
+import com.google.maps.model.LatLng;
+import com.google.maps.model.PlacesSearchResult;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GooglePlacesService {
+
+  private final GeoApiContext context;
+
+  public GooglePlacesService(@Value("${google.maps.api.key}") String apiKey)  {
+    this.context = new GeoApiContext.Builder()
+        .apiKey(apiKey)
+        .build();
+  }
+
+  // 기존 장소 검색
+  public PlacesSearchResult searchPlace(String placeName) {
+    try {
+      return PlacesApi.textSearchQuery(context, placeName).await().results[0];
+    } catch (Exception e) {
+      throw new RuntimeException("장소 세부정보를 가져오지 못했습니다.", e);
+    }
+  }
+
+  // 특정 위치 기준으로 반경 5km 내의 인기 장소 검색
+  public List<PlacesSearchResult> searchNearbyPlaces(double latitude, double longitude, int radius) {
+    try {
+      return Arrays.asList(PlacesApi.nearbySearchQuery(context, new LatLng(latitude, longitude))
+          .radius(radius)
+          .await()
+          .results);
+    } catch (Exception e) {
+      throw new RuntimeException("주변 장소를 가져오지 못했습니다.", e);
+    }
+  }
+}

--- a/src/main/java/daehun/trip_java/Search/service/PlaceDataService.java
+++ b/src/main/java/daehun/trip_java/Search/service/PlaceDataService.java
@@ -1,0 +1,23 @@
+package daehun.trip_java.Search.service;
+
+import daehun.trip_java.Search.domain.Place;
+import daehun.trip_java.Search.repository.PlaceRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PlaceDataService {
+
+  private final PlaceRepository placeRepository;
+  private final SeoulOpenDataService seoulOpenDataService;
+
+  public PlaceDataService(PlaceRepository placeRepository, SeoulOpenDataService seoulOpenDataService) {
+    this.placeRepository = placeRepository;
+    this.seoulOpenDataService = seoulOpenDataService;
+  }
+
+  public void saveTouristAttractions() {
+    List<Place> places = seoulOpenDataService.getTouristAttractions();
+    placeRepository.saveAll(places);
+  }
+}

--- a/src/main/java/daehun/trip_java/Search/service/PlaceService.java
+++ b/src/main/java/daehun/trip_java/Search/service/PlaceService.java
@@ -1,0 +1,55 @@
+package daehun.trip_java.Search.service;
+
+import com.google.maps.model.PlacesSearchResult;
+import daehun.trip_java.Search.domain.Place;
+import daehun.trip_java.Search.repository.PlaceRepository;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PlaceService {
+
+  private final PlaceRepository placeRepository;
+  private final GooglePlacesService googlePlacesService;
+
+  public PlaceService(PlaceRepository placeRepository, GooglePlacesService googlePlacesService) {
+    this.placeRepository = placeRepository;
+    this.googlePlacesService = googlePlacesService;
+  }
+
+  // 기존 장소 검색
+  public Place getPlaceByName(String name) {
+    return placeRepository.findByName(name)
+        .orElseGet(() -> {
+          PlacesSearchResult googlePlace = googlePlacesService.searchPlace(name);
+          Place place = mapToPlace(googlePlace);
+          return placeRepository.save(place);
+        });
+  }
+
+  // 특정 위치 기준으로 반경 5km 내 인기 장소 검색 및 ES에 저장
+  public List<Place> getNearbyPlaces(double latitude, double longitude) {
+    List<PlacesSearchResult> googlePlaces = googlePlacesService.searchNearbyPlaces(latitude, longitude, 5000);
+
+    List<Place> places = googlePlaces.stream()
+        .map(this::mapToPlace)
+        .sorted(Comparator.comparingDouble(Place::getRating).reversed()) // 평점에 따라 정렬
+        .map(placeRepository::save)
+        .collect(Collectors.toList());
+
+    return places;
+  }
+
+  // GooglePlaces API 결과 -> Place 엔티티로 매핑
+  private Place mapToPlace(PlacesSearchResult googlePlace) {
+    Place place = new Place();
+    place.setName(googlePlace.name);
+    place.setAddress(googlePlace.formattedAddress);
+    place.setLatitude(googlePlace.geometry.location.lat);
+    place.setLongitude(googlePlace.geometry.location.lng);
+    place.setRating(googlePlace.rating);
+    return place;
+  }
+}

--- a/src/main/java/daehun/trip_java/Search/service/PlaceService.java
+++ b/src/main/java/daehun/trip_java/Search/service/PlaceService.java
@@ -3,8 +3,10 @@ package daehun.trip_java.Search.service;
 import com.google.maps.model.PlacesSearchResult;
 import daehun.trip_java.Search.domain.Place;
 import daehun.trip_java.Search.repository.PlaceRepository;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
@@ -21,25 +23,44 @@ public class PlaceService {
 
   // 기존 장소 검색
   public Place getPlaceByName(String name) {
-    return placeRepository.findByName(name)
-        .orElseGet(() -> {
-          PlacesSearchResult googlePlace = googlePlacesService.searchPlace(name);
-          Place place = mapToPlace(googlePlace);
-          return placeRepository.save(place);
-        });
+    Optional<Place> existingPlace = placeRepository.findByName(name);
+
+    // ES에 저장된 데이터가 있는 경우 :데이터 최신성 확인
+    if (existingPlace.isPresent()) {
+      Place place = existingPlace.get();
+
+      // 최신성 검증 로직
+      if (isDataStale(place)) {
+        PlacesSearchResult googlePlace = googlePlacesService.searchPlace(name);
+        Place updatedPlace = mapToPlace(googlePlace);
+        updatedPlace.setId(place.getId()); // 기존 데이터 ID 유지
+        placeRepository.save(updatedPlace);
+        return updatedPlace;
+      }
+
+      return place; // 최신 데이터 반환
+    }
+
+    // ES에 데이터가 없을 경우 Google Places API 호출 후 저장
+    PlacesSearchResult googlePlace = googlePlacesService.searchPlace(name);
+    Place newPlace = mapToPlace(googlePlace);
+    return placeRepository.save(newPlace);
+  }
+
+  // ES 데이터 최신성 확인 로직(1일 1회)
+  private boolean isDataStale(Place place) {
+    return place.getUpdatedAt().isBefore(LocalDateTime.now().minusDays(1));
   }
 
   // 특정 위치 기준으로 반경 5km 내 인기 장소 검색 및 ES에 저장
   public List<Place> getNearbyPlaces(double latitude, double longitude) {
     List<PlacesSearchResult> googlePlaces = googlePlacesService.searchNearbyPlaces(latitude, longitude, 5000);
 
-    List<Place> places = googlePlaces.stream()
+    return googlePlaces.stream()
         .map(this::mapToPlace)
         .sorted(Comparator.comparingDouble(Place::getRating).reversed()) // 평점에 따라 정렬
-        .map(placeRepository::save)
+        .map(placeRepository::save) // ES 저장
         .collect(Collectors.toList());
-
-    return places;
   }
 
   // GooglePlaces API 결과 -> Place 엔티티로 매핑
@@ -50,6 +71,7 @@ public class PlaceService {
     place.setLatitude(googlePlace.geometry.location.lat);
     place.setLongitude(googlePlace.geometry.location.lng);
     place.setRating(googlePlace.rating);
+    place.setUpdatedAt(LocalDateTime.now()); // 최신성 확인
     return place;
   }
 }

--- a/src/main/java/daehun/trip_java/Search/service/SeoulOpenDataService.java
+++ b/src/main/java/daehun/trip_java/Search/service/SeoulOpenDataService.java
@@ -4,6 +4,8 @@ import daehun.trip_java.Search.domain.Place;
 import daehun.trip_java.Search.dto.TouristAttractionsResponse;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -11,6 +13,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 public class SeoulOpenDataService {
+
+  private static final Logger logger = LoggerFactory.getLogger(SeoulOpenDataService.class);
 
   private final RestTemplate restTemplate;
 
@@ -27,22 +31,33 @@ public class SeoulOpenDataService {
         .build()
         .toUriString();
 
-    TouristAttractionsResponse response = restTemplate.getForObject(url, TouristAttractionsResponse.class);
-
-    return mapToPlaces(response);
+    try{
+      TouristAttractionsResponse response = restTemplate.getForObject(url, TouristAttractionsResponse.class);
+      return mapToPlaces(response);
+    } catch (Exception e) {
+      logger.error("서울시 오픈데이터 API에서 관광명소 정보를 가져오는데 실패했습니다.", e);
+      throw new RuntimeException("서울시 오픈데이터 API에서 관광명소 정보를 가져오는데 실패했습니다.", e);
+    }
   }
 
   private List<Place> mapToPlaces(TouristAttractionsResponse response) {
     List<Place> places = new ArrayList<>();
-    if (response != null && response.getTouristAttractionsInfo() != null) {
-      for (TouristAttractionsResponse.TouristAttraction attraction : response.getTouristAttractionsInfo().getAttractions()) {
-        Place place = new Place();
-        place.setName(attraction.getName());
-        place.setAddress(attraction.getAddress());
-        place.setLatitude(attraction.getLatitude());
-        place.setLongitude(attraction.getLongitude());
-        places.add(place);
+
+    try {
+      if (response != null && response.getTouristAttractionsInfo() != null) {
+        for (TouristAttractionsResponse.TouristAttraction attraction : response.getTouristAttractionsInfo()
+            .getAttractions()) {
+          Place place = new Place();
+          place.setName(attraction.getName());
+          place.setAddress(attraction.getAddress());
+          place.setLatitude(attraction.getLatitude());
+          place.setLongitude(attraction.getLongitude());
+          places.add(place);
+        }
       }
+    } catch (Exception e) {
+      logger.error("관광명소를 호출하는 과정에서 오류가 발생했습니다.", e);
+      throw new RuntimeException("관광명소를 호출하는 과정에서 오류가 발생했습니다.", e);
     }
     return places;
   }

--- a/src/main/java/daehun/trip_java/Search/service/SeoulOpenDataService.java
+++ b/src/main/java/daehun/trip_java/Search/service/SeoulOpenDataService.java
@@ -1,0 +1,52 @@
+package daehun.trip_java.Search.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import daehun.trip_java.Search.domain.Place;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class SeoulOpenDataService {
+
+  private final RestTemplate restTemplate;
+  private final ObjectMapper objectMapper;
+
+  @Value("${seoul.api.key}")
+  private String apiKey;
+
+  public SeoulOpenDataService(RestTemplate restTemplate, ObjectMapper objectMapper) {
+    this.restTemplate = restTemplate;
+    this.objectMapper = objectMapper;
+  }
+
+  public List<Place> getTouristAttractions() {
+    String url = String.format("http://openapi.seoul.go.kr:8088/%s/json/TouristAttractionsInfo/1/1000/", apiKey);
+    String response = restTemplate.getForObject(url, String.class);
+
+    return parseResponse(response);
+  }
+
+  private List<Place> parseResponse(String response) {
+    List<Place> places = new ArrayList<>();
+    try {
+      JsonNode root = objectMapper.readTree(response);
+      JsonNode items = root.path("TouristAttractionsInfo").path("row");
+
+      for (JsonNode item : items) {
+        Place place = new Place();
+        place.setName(item.path("POST_SJ").asText());
+        place.setAddress(item.path("ADDRESS").asText());
+        place.setLatitude(item.path("Y").asDouble());
+        place.setLongitude(item.path("X").asDouble());
+        places.add(place);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return places;
+  }
+}

--- a/src/main/java/daehun/trip_java/Search/service/SeoulOpenDataService.java
+++ b/src/main/java/daehun/trip_java/Search/service/SeoulOpenDataService.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 public class SeoulOpenDataService {
@@ -24,7 +25,11 @@ public class SeoulOpenDataService {
   }
 
   public List<Place> getTouristAttractions() {
-    String url = String.format("http://openapi.seoul.go.kr:8088/%s/json/TouristAttractionsInfo/1/1000/", apiKey);
+    String url = UriComponentsBuilder.fromHttpUrl("http://openapi.seoul.go.kr:8088")
+        .pathSegment(apiKey, "json", "TouristAttractionsInfo", "1", "1000")
+        .build()
+        .toUriString();
+
     String response = restTemplate.getForObject(url, String.class);
 
     return parseResponse(response);

--- a/src/main/java/daehun/trip_java/Trip/controller/TripController.java
+++ b/src/main/java/daehun/trip_java/Trip/controller/TripController.java
@@ -1,0 +1,41 @@
+package daehun.trip_java.Trip.controller;
+
+import daehun.trip_java.Trip.domain.Trip;
+import daehun.trip_java.Trip.service.TripService;
+import daehun.trip_java.User.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/trips")
+@RequiredArgsConstructor
+public class TripController {
+
+  private final TripService tripService;
+
+  @GetMapping
+  public String getTrips(Model model, @AuthenticationPrincipal User user) {
+    List<Trip> trips = tripService.getTripsByUsername(user.getUsername());
+    model.addAttribute("trips", trips);
+    return "tripList";
+  }
+
+  @GetMapping("/new")
+  public String newTripForm(Model model) {
+    model.addAttribute("trip", new Trip());
+    return "newTrip";
+  }
+
+  @PostMapping
+  public String createTrip(@AuthenticationPrincipal User user, @ModelAttribute Trip trip) {
+    tripService.createTrip(user.getUsername(), trip.getTripName(), trip.getStartDate(), trip.getEndDate());
+    return "redirect:/trips";
+  }
+}

--- a/src/main/java/daehun/trip_java/Trip/domain/Trip.java
+++ b/src/main/java/daehun/trip_java/Trip/domain/Trip.java
@@ -1,0 +1,60 @@
+package daehun.trip_java.Trip.domain;
+
+import daehun.trip_java.User.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "trip")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Trip {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long tripId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "userId", nullable = false)
+  private User user;
+
+  @Column(nullable = false)
+  private String tripName;
+
+  @Column(nullable = false)
+  private LocalDate startDate;
+
+  @Column(nullable = false)
+  private LocalDate endDate;
+
+  private LocalDateTime createdAt;
+
+  private LocalDateTime updatedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    createdAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    updatedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/daehun/trip_java/Trip/repository/TripRepository.java
+++ b/src/main/java/daehun/trip_java/Trip/repository/TripRepository.java
@@ -1,0 +1,10 @@
+package daehun.trip_java.Trip.repository;
+
+import daehun.trip_java.Trip.domain.Trip;
+import daehun.trip_java.User.domain.User;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripRepository extends JpaRepository<Trip, Long > {
+  List<Trip> findByUser(User user);
+}

--- a/src/main/java/daehun/trip_java/Trip/service/TripService.java
+++ b/src/main/java/daehun/trip_java/Trip/service/TripService.java
@@ -1,0 +1,36 @@
+package daehun.trip_java.Trip.service;
+
+import daehun.trip_java.Trip.domain.Trip;
+import daehun.trip_java.Trip.repository.TripRepository;
+import daehun.trip_java.User.domain.User;
+import daehun.trip_java.User.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TripService {
+  private final TripRepository tripRepository;
+  private final UserRepository userRepository;
+
+  public Trip createTrip(String username, String tripName, LocalDate startDate, LocalDate endDate) {
+    User user = userRepository.findByUsername(username)
+        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾지 못했습니다."));
+
+    Trip trip = new Trip();
+    trip.setUser(user);
+    trip.setTripName(tripName);
+    trip.setStartDate(startDate);
+    trip.setEndDate(endDate);
+    return tripRepository.save(trip);
+  }
+
+  public List<Trip> getTripsByUsername(String username) {
+    User user = userRepository.findByUsername(username)
+        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾기 못했습니다."));
+    return tripRepository.findByUser(user);
+  }
+}

--- a/src/main/java/daehun/trip_java/Trip/service/TripService.java
+++ b/src/main/java/daehun/trip_java/Trip/service/TripService.java
@@ -30,7 +30,7 @@ public class TripService {
 
   public List<Trip> getTripsByUsername(String username) {
     User user = userRepository.findByUsername(username)
-        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾기 못했습니다."));
+        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾지 못했습니다."));
     return tripRepository.findByUser(user);
   }
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 사용자 입력 여행지 및 식당 데이터 검색하는 기능 미구현
- ElasticSearch 및 Google Places API & 서울 열린데이터 광장 API와의 연동 기능 미구현

**TO-BE**
- ElasticSearch 및 Google Places API & 서울 열린데이터 광장 API 연동
  - GooglePlacesService를 통해 Google Places API를 사용하여 특정 위치 기준으로 반경 5km 내의 인기 장소를 검색하고, 그 데이터를 ElasticSearch에 저장하도록 구현
  - PlaceService에서 ElasticSearch를 통해 저장된 장소 데이터를 검색하거나, 저장되지 않은 경우 Google Places API에서 데이터를 가져와 저장하는 기능 구현
  - 서울시 열린데이터 광장 API와 연동하여 서울시 관광 명소 및 식당 데이터를 ElasticSearch에 저장하도록 SeoulOpenDataService 구현

- RestTemplate(AppConfig) : Bean을 제공하여 외부 API와의 통신 지원

- Place
  - ElasticSearch에 저장될 장소 데이터
  - Document : ElasticSearch 인덱스에서 관리되는 문서 명시
  - Field : 각 필드 ElasticSearch에 저장될 데이터 타입 지정 

- PlaceService
  - getPlaceByName() : Elasticsearch에서 장소를 찾거나, 찾을 수 없으면 Google Places API를 통해 검색한 후 저장
  - getNearbyPlaces() : 특정 위치를 기준으로 반경 내의 장소를 Google Places API를 통해 검색하고 Elasticsearch에 저장

- PlaceController
  - getPlace() : 특정 장소 이름 사용해 ElasticSearch에서 장소 검색
  - getNearbyPlaces() : 특정 위치(위·경도)를 기준으로 반경 내 장소 검색
  - collectSeoulData() : 서울시 공공 데이터 API를 통해 관광지 정보 가져와 ElasticSearch 저장

- PlaceRepository
  -  ElasticsearchRepository 확장하여 기본적인 CRUD 제공

- PlaceDataService
  - 서울시 공공 데이터 API로부터 데이터를 가져와서 ElasticSearch에 저장
  
- SeoulOpenDataService
  - 서울시 열린 데이터 광장 API와 연동하여 데이터를 가져오는 서비스
  - getTouristAttractions() : 서울시 관광지 정보를 API로부터 가져와 Place 객체의 리스트로 반환

- TripController
  - getTrips() : 로그인한 사용자의 모든 여행 일정을 가져오기
  - newTripForm() : 새로운 여행 일정을 만들기 위한 폼
  - createTrip() : 사용자가 입력한 정보를 기반으로 새로운 여행 일정 생성

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 