### PR TITLE
Feature/cart

### DIFF
--- a/src/main/java/daehun/trip_java/Cart/Controller/CartController.java
+++ b/src/main/java/daehun/trip_java/Cart/Controller/CartController.java
@@ -1,0 +1,50 @@
+package daehun.trip_java.Cart.Controller;
+
+import daehun.trip_java.Cart.Service.CartService;
+import daehun.trip_java.Cart.domain.Cart;
+import daehun.trip_java.User.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/cart")
+@RequiredArgsConstructor
+public class CartController {
+  private final CartService cartService;
+
+  // 장바구니 여행지 추가
+  @PostMapping
+  public ResponseEntity<Cart> addToCart(@AuthenticationPrincipal User user, @RequestParam Long placeId) {
+    Cart cart = cartService.addToCart(user, placeId);
+    return ResponseEntity.ok(cart);
+  }
+
+  // 장바구니 항목 조회
+  @GetMapping
+  public ResponseEntity<List<Cart>> getCartItems(@AuthenticationPrincipal User user) {
+    List<Cart> cartItems = cartService.getCartItemsByUser(user);
+    return ResponseEntity.ok(cartItems);
+  }
+
+  // 장바구니에서 특정 여행지 제거
+  @DeleteMapping
+  public ResponseEntity<Void> removeFromCart(@AuthenticationPrincipal User user, @RequestParam Long placeId) {
+    cartService.removeFromCart(user, placeId);
+    return ResponseEntity.noContent().build();
+  }
+
+  // 장바구니 비우기
+  @DeleteMapping("/clear")
+  public ResponseEntity<Void> clearCart(@AuthenticationPrincipal User user) {
+    cartService.clearCart(user);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/daehun/trip_java/Cart/Controller/FavoriteController.java
+++ b/src/main/java/daehun/trip_java/Cart/Controller/FavoriteController.java
@@ -1,0 +1,50 @@
+package daehun.trip_java.Cart.Controller;
+
+import daehun.trip_java.Cart.Service.FavoriteService;
+import daehun.trip_java.Cart.domain.Favorite;
+import daehun.trip_java.User.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/favorites")
+@RequiredArgsConstructor
+public class FavoriteController {
+  private final FavoriteService favoriteService;
+
+  // 여행 즐겨찾기 추가
+  @PostMapping("/{tripId}")
+  public ResponseEntity<Favorite> addFavorite(@AuthenticationPrincipal User user, @PathVariable Long tripId) {
+    Favorite favorite = favoriteService.addFavorite(user, tripId);
+    return ResponseEntity.ok(favorite);
+  }
+
+  // 사용자의 즐겨찾기 목록 조회
+  @GetMapping
+  public ResponseEntity<List<Favorite>> getFavorites(@AuthenticationPrincipal User user) {
+    List<Favorite> favorites = favoriteService.getFavoritesByUser(user);
+    return ResponseEntity.ok(favorites);
+  }
+
+  // 여행 즐겨찾기 제거
+  @DeleteMapping("/{tripId}")
+  public ResponseEntity<Void> removeFavorite(@AuthenticationPrincipal User user, @PathVariable Long tripId) {
+    favoriteService.removeFavorite(user, tripId);
+    return ResponseEntity.noContent().build();
+  }
+
+  // 즐겨찾기 여부 확인
+  @GetMapping("/{tripId}/exists")
+  public ResponseEntity<Boolean> isFavorite(@AuthenticationPrincipal User user, @PathVariable Long tripId) {
+    boolean isFavorite = favoriteService.isFavorite(user, tripId);
+    return ResponseEntity.ok(isFavorite);
+  }
+}

--- a/src/main/java/daehun/trip_java/Cart/Repository/CartRepository.java
+++ b/src/main/java/daehun/trip_java/Cart/Repository/CartRepository.java
@@ -1,0 +1,11 @@
+package daehun.trip_java.Cart.Repository;
+
+import daehun.trip_java.Cart.domain.Cart;
+import daehun.trip_java.User.domain.User;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+  List<Cart> findByUser(User user);
+  void deleteByUserAndPlaceId(User user, Long placeId);
+}

--- a/src/main/java/daehun/trip_java/Cart/Repository/CartRepository.java
+++ b/src/main/java/daehun/trip_java/Cart/Repository/CartRepository.java
@@ -6,6 +6,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
-  List<Cart> findByUser(User user);
+  List<Cart> findAllByUser(User user);
   void deleteByUserAndPlaceId(User user, Long placeId);
 }

--- a/src/main/java/daehun/trip_java/Cart/Repository/CartRepository.java
+++ b/src/main/java/daehun/trip_java/Cart/Repository/CartRepository.java
@@ -2,10 +2,19 @@ package daehun.trip_java.Cart.Repository;
 
 import daehun.trip_java.Cart.domain.Cart;
 import daehun.trip_java.User.domain.User;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
   List<Cart> findAllByUser(User user);
   void deleteByUserAndPlaceId(User user, Long placeId);
+
+  @Modifying
+  @Transactional
+  @Query(value = "DELETE FROM cart WHERE user_id = :userId", nativeQuery = true)
+  void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/daehun/trip_java/Cart/Repository/FavoriteRepository.java
+++ b/src/main/java/daehun/trip_java/Cart/Repository/FavoriteRepository.java
@@ -1,0 +1,15 @@
+package daehun.trip_java.Cart.Repository;
+
+import daehun.trip_java.Cart.domain.Favorite;
+import daehun.trip_java.Trip.domain.Trip;
+import daehun.trip_java.User.domain.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+  List<Favorite> findByUser(User user);
+  Optional<Favorite> findByUserAndTrip(User user, Trip trip);
+  void deleteByUserAndTrip(User user, Trip trip);
+  boolean existsByUserAndTrip(User user, Trip trip);
+}

--- a/src/main/java/daehun/trip_java/Cart/Repository/FavoriteRepository.java
+++ b/src/main/java/daehun/trip_java/Cart/Repository/FavoriteRepository.java
@@ -3,12 +3,13 @@ package daehun.trip_java.Cart.Repository;
 import daehun.trip_java.Cart.domain.Favorite;
 import daehun.trip_java.Trip.domain.Trip;
 import daehun.trip_java.User.domain.User;
-import java.util.List;
+import java.awt.print.Pageable;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
-  List<Favorite> findByUser(User user);
+  Page<Favorite> findByUser(User user, Pageable pageable);
   Optional<Favorite> findByUserAndTrip(User user, Trip trip);
   void deleteByUserAndTrip(User user, Trip trip);
   boolean existsByUserAndTrip(User user, Trip trip);

--- a/src/main/java/daehun/trip_java/Cart/Service/CartService.java
+++ b/src/main/java/daehun/trip_java/Cart/Service/CartService.java
@@ -30,7 +30,7 @@ public class CartService {
 
   // 특정 사용자의 모든 장바구니 항목 조회
   public List<Cart> getCartItemsByUser(User user) {
-    return cartRepository.findByUser(user);
+    return cartRepository.findAllByUser(user);
   }
 
   // 사용자의 장바구니에서 특정 여행지 제거
@@ -40,7 +40,7 @@ public class CartService {
 
   // 사용자의 모든 장바구니 항목 제거
   public void clearCart(User user) {
-    List<Cart> cartItems = cartRepository.findByUser(user);
+    List<Cart> cartItems = cartRepository.findAllByUser(user);
     cartRepository.deleteAll(cartItems);
   }
 }

--- a/src/main/java/daehun/trip_java/Cart/Service/CartService.java
+++ b/src/main/java/daehun/trip_java/Cart/Service/CartService.java
@@ -1,0 +1,38 @@
+package daehun.trip_java.Cart.Service;
+
+import daehun.trip_java.Cart.Repository.CartRepository;
+import daehun.trip_java.Cart.domain.Cart;
+import daehun.trip_java.User.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+  private final CartRepository cartRepository;
+
+  // 사용자가 여행지를 장바구니에 추가
+  public Cart addToCart(User user, Long placeId) {
+    Cart cart = new Cart();
+    cart.setUser(user);
+    cart.setPlaceId(placeId);
+    return cartRepository.save(cart);
+  }
+
+  // 특정 사용자의 모든 장바구니 항목 조회
+  public List<Cart> getCartItemsByUser(User user) {
+    return cartRepository.findByUser(user);
+  }
+
+  // 사용자의 장바구니에서 특정 여행지 제거
+  public void removeFromCart(User user, Long placeId) {
+    cartRepository.deleteByUserAndPlaceId(user, placeId);
+  }
+
+  // 사용자의 모든 장바구니 항목 제거
+  public void clearCart(User user) {
+    List<Cart> cartItems = cartRepository.findByUser(user);
+    cartRepository.deleteAll(cartItems);
+  }
+}

--- a/src/main/java/daehun/trip_java/Cart/Service/CartService.java
+++ b/src/main/java/daehun/trip_java/Cart/Service/CartService.java
@@ -2,6 +2,7 @@ package daehun.trip_java.Cart.Service;
 
 import daehun.trip_java.Cart.Repository.CartRepository;
 import daehun.trip_java.Cart.domain.Cart;
+import daehun.trip_java.Search.service.PlaceService;
 import daehun.trip_java.User.domain.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -11,9 +12,16 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CartService {
   private final CartRepository cartRepository;
+  private final PlaceService placeService;
 
   // 사용자가 여행지를 장바구니에 추가
   public Cart addToCart(User user, Long placeId) {
+
+    // Place 존재 여부 확인
+    if (placeService.getPlaceById(placeId).isEmpty()) {
+      throw new IllegalArgumentException("유효하지 않은 여행지입니다.");
+    }
+
     Cart cart = new Cart();
     cart.setUser(user);
     cart.setPlaceId(placeId);

--- a/src/main/java/daehun/trip_java/Cart/Service/CartService.java
+++ b/src/main/java/daehun/trip_java/Cart/Service/CartService.java
@@ -40,7 +40,6 @@ public class CartService {
 
   // 사용자의 모든 장바구니 항목 제거
   public void clearCart(User user) {
-    List<Cart> cartItems = cartRepository.findAllByUser(user);
-    cartRepository.deleteAll(cartItems);
+    cartRepository.deleteAllByUserId(user.getUserId());
   }
 }

--- a/src/main/java/daehun/trip_java/Cart/Service/FavoriteService.java
+++ b/src/main/java/daehun/trip_java/Cart/Service/FavoriteService.java
@@ -5,8 +5,9 @@ import daehun.trip_java.Cart.domain.Favorite;
 import daehun.trip_java.Trip.domain.Trip;
 import daehun.trip_java.Trip.repository.TripRepository;
 import daehun.trip_java.User.domain.User;
-import java.util.List;
+import java.awt.print.Pageable;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -32,8 +33,8 @@ public class FavoriteService {
   }
 
   // 특정 사용자의 모든 즐겨찾기 항목 조회
-  public List<Favorite> getFavoritesByUser(User user) {
-    return favoriteRepository.findByUser(user);
+  public Page<Favorite> getFavoritesByUser(User user, Pageable pageable) {
+    return favoriteRepository.findByUser(user, pageable);
   }
 
   // 사용자의 즐겨찾기에서 특정 여행 제거

--- a/src/main/java/daehun/trip_java/Cart/Service/FavoriteService.java
+++ b/src/main/java/daehun/trip_java/Cart/Service/FavoriteService.java
@@ -1,0 +1,52 @@
+package daehun.trip_java.Cart.Service;
+
+import daehun.trip_java.Cart.Repository.FavoriteRepository;
+import daehun.trip_java.Cart.domain.Favorite;
+import daehun.trip_java.Trip.domain.Trip;
+import daehun.trip_java.Trip.repository.TripRepository;
+import daehun.trip_java.User.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteService {
+  private final FavoriteRepository favoriteRepository;
+  private final TripRepository tripRepository;
+
+  // 사용자가 여행을 즐겨찾기에 추가
+  public Favorite addFavorite(User user, Long tripId) {
+    Trip trip = tripRepository.findById(tripId)
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 여행 ID입니다."));
+
+    // 이미 즐겨찾기에 추가된 경우 예외 처리
+    if (favoriteRepository.existsByUserAndTrip(user, trip)) {
+      throw new IllegalArgumentException("이미 즐겨찾기에 추가된 여행입니다.");
+    }
+
+    Favorite favorite = new Favorite();
+    favorite.setUser(user);
+    favorite.setTrip(trip);
+    return favoriteRepository.save(favorite);
+  }
+
+  // 특정 사용자의 모든 즐겨찾기 항목 조회
+  public List<Favorite> getFavoritesByUser(User user) {
+    return favoriteRepository.findByUser(user);
+  }
+
+  // 사용자의 즐겨찾기에서 특정 여행 제거
+  public void removeFavorite(User user, Long tripId) {
+    Trip trip = tripRepository.findById(tripId)
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 여행 ID입니다."));
+    favoriteRepository.deleteByUserAndTrip(user, trip);
+  }
+
+  // 즐겨찾기 여부 확인
+  public boolean isFavorite(User user, Long tripId) {
+    Trip trip = tripRepository.findById(tripId)
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 여행 ID입니다."));
+    return favoriteRepository.existsByUserAndTrip(user, trip);
+  }
+}

--- a/src/main/java/daehun/trip_java/Cart/domain/Cart.java
+++ b/src/main/java/daehun/trip_java/Cart/domain/Cart.java
@@ -1,0 +1,46 @@
+package daehun.trip_java.Cart.domain;
+
+import daehun.trip_java.User.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "cart")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Cart {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long cartId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(name = "place_id", nullable = false)
+  private Long placeId;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @PrePersist
+  protected void onCreate() {
+    createdAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/daehun/trip_java/Cart/domain/Favorite.java
+++ b/src/main/java/daehun/trip_java/Cart/domain/Favorite.java
@@ -1,0 +1,48 @@
+package daehun.trip_java.Cart.domain;
+
+import daehun.trip_java.Trip.domain.Trip;
+import daehun.trip_java.User.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "favorite")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Favorite {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long favorId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "trip_id", nullable = false)
+  private Trip trip;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @PrePersist
+  protected void onCreate() {
+    createdAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/daehun/trip_java/Search/controller/PlaceController.java
+++ b/src/main/java/daehun/trip_java/Search/controller/PlaceController.java
@@ -4,6 +4,8 @@ import daehun.trip_java.Search.domain.Place;
 import daehun.trip_java.Search.service.PlaceDataService;
 import daehun.trip_java.Search.service.PlaceService;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,6 +29,13 @@ public class PlaceController {
   @GetMapping("/{name}")
   public Place getPlace(@PathVariable String name) {
     return placeService.getPlaceByName(name);
+  }
+
+  // 장바구니 연동
+  @GetMapping("/{id}")
+  public ResponseEntity<Place> getPlaceById(@PathVariable Long id) {
+    Optional<Place> place = placeService.getPlaceById(id);
+    return place.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
   }
 
   // 반경 내 장소 검색

--- a/src/main/java/daehun/trip_java/Search/service/PlaceService.java
+++ b/src/main/java/daehun/trip_java/Search/service/PlaceService.java
@@ -47,6 +47,11 @@ public class PlaceService {
     return placeRepository.save(newPlace);
   }
 
+  // ID로 장소 검색
+  public Optional<Place> getPlaceById(Long id) {
+    return placeRepository.findById(id);
+  }
+
   // ES 데이터 최신성 확인 로직(1일 1회)
   private boolean isDataStale(Place place) {
     return place.getUpdatedAt().isBefore(LocalDateTime.now().minusDays(1));

--- a/src/main/java/daehun/trip_java/Trip/domain/Trip.java
+++ b/src/main/java/daehun/trip_java/Trip/domain/Trip.java
@@ -51,11 +51,6 @@ public class Trip {
   @Column(nullable = false)
   private LocalDate endDate;
 
-  @ElementCollection
-  @CollectionTable(name = "trip_places", joinColumns = @JoinColumn(name = "trip_id"))
-  @Column(name = "place_id")
-  private List<Long> placeIds; // ES에 있는 Place의 ID만 저장
-
   @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<History> histories;
 

--- a/src/main/java/daehun/trip_java/Trip/domain/Trip.java
+++ b/src/main/java/daehun/trip_java/Trip/domain/Trip.java
@@ -1,5 +1,6 @@
 package daehun.trip_java.Trip.domain;
 
+import daehun.trip_java.Cart.domain.Favorite;
 import daehun.trip_java.History.domain.History;
 import daehun.trip_java.User.domain.User;
 import jakarta.persistence.CascadeType;
@@ -50,6 +51,9 @@ public class Trip {
 
   @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<History> histories;
+
+  @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Favorite> favorites;
 
   private LocalDateTime createdAt;
 

--- a/src/main/java/daehun/trip_java/Trip/domain/Trip.java
+++ b/src/main/java/daehun/trip_java/Trip/domain/Trip.java
@@ -4,7 +4,9 @@ import daehun.trip_java.Cart.domain.Favorite;
 import daehun.trip_java.History.domain.History;
 import daehun.trip_java.User.domain.User;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -48,6 +50,11 @@ public class Trip {
 
   @Column(nullable = false)
   private LocalDate endDate;
+
+  @ElementCollection
+  @CollectionTable(name = "trip_places", joinColumns = @JoinColumn(name = "trip_id"))
+  @Column(name = "place_id")
+  private List<Long> placeIds; // ES에 있는 Place의 ID만 저장
 
   @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<History> histories;

--- a/src/main/java/daehun/trip_java/User/domain/User.java
+++ b/src/main/java/daehun/trip_java/User/domain/User.java
@@ -1,12 +1,18 @@
 package daehun.trip_java.User.domain;
 
+import daehun.trip_java.Cart.domain.Cart;
+import daehun.trip_java.Cart.domain.Favorite;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,4 +40,10 @@ public class User {
   private LocalDateTime createdAt;
 
   private LocalDateTime updatedAt;
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Cart> carts = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Favorite> favorites = new ArrayList<>();
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 여행을 장바구니(Cart)에 담아 여행지 조회, 추가, 제거 기능 미구현
- 즐겨찾기(Favorite)에 여행지를 추가하고 관리하는 기능 미구현
- Cart, Favorite 기능 구현에 따른 다른 테이블 간의 관계 설정 미구현
- Elasticsearch를 사용하는 Place 엔티티와 JPA 엔티티 간의 연동 미구현

<br>

**TO-BE**
- 즐겨찾기 기능 구현
  - Favorite 엔티티와 Trip 엔티티, User 엔티티 간의 관계 설정 (@ManyToOne 관계 설정)
  - 사용자(User)와 여행(Trip) 간의 즐겨찾기 기능을 추가하여 Favorite 엔티티를 통해 관리
  - 사용자가 특정 여행지를 즐겨찾기에 추가하고 삭제할 수 있는 기능 구현 (FavoriteController 및 FavoriteService)
  - 즐겨찾기 여부 확인 기능 추가로 인한 사용자가 특정 여행지가 즐겨찾기에 추가되었는지 확인

<br>

- 장바구니 기능 구현
  - Cart 엔티티와 User 엔티티 간의 관계 설정 (@ManyToOne 관계 설정)
  - 사용자(User)가 특정 여행지(Place)를 장바구니에 추가하고, 장바구니에 있는 여행지 목록을 조회하거나 삭제할 수 있는 기능 구현 (CartController 및 CartService)
  - 장바구니에서 여행지의 유효성을 확인하기 위해 Elasticsearch에서 Place 데이터를 가져와서 검증
  
<br>

- Place와의 연동 기능 구현
  - 장바구니 및 즐겨찾기 기능에서 여행지(Place) 데이터를 연동하기 위해 PlaceService를 통한 ID 기반 조회 기능 추가
  - 장바구니에 여행지를 추가할 때, Place의 존재 여부를 확인하여 유효성을 검증
  - Trip 및 History 엔티티와 Place 간의 연동을 통해, 사용자가 선택한 여행지 정보가 Elasticsearch에서 관리되는 Place와 연결되도록 구현

<br>

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 