### PR TITLE
feat : 체크리스트 기능 구현(엔티티 설계, CRUD, 진행률)

### DIFF
--- a/src/main/java/daehun/trip_java/Checklist/Controller/ChecklistController.java
+++ b/src/main/java/daehun/trip_java/Checklist/Controller/ChecklistController.java
@@ -1,0 +1,63 @@
+package daehun.trip_java.Checklist.Controller;
+
+import daehun.trip_java.Checklist.Service.ChecklistService;
+import daehun.trip_java.Checklist.domain.Checklist;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/checklists")
+@RequiredArgsConstructor
+public class ChecklistController {
+
+  private final ChecklistService checklistService;
+
+  // 체크리스트 항목 생성
+  @PostMapping
+  public ResponseEntity<Checklist> createChecklist(@RequestParam Long tripId,
+      @RequestParam String item,
+      @RequestParam String memo) {
+    Checklist checklist = checklistService.createChecklist(tripId, item, memo);
+    return ResponseEntity.ok(checklist);
+  }
+
+  // 특정 여행의 체크리스트 조회
+  @GetMapping("/trip/{tripId}")
+  public ResponseEntity<List<Checklist>> getChecklistsByTrip(@PathVariable Long tripId) {
+    List<Checklist> checklists = checklistService.getChecklistsByTrip(tripId);
+    return ResponseEntity.ok(checklists);
+  }
+
+  // 체크리스트 항목 수정
+  @PutMapping("/{checkId}")
+  public ResponseEntity<Checklist> updateChecklist(@PathVariable Long checkId,
+      @RequestParam String item,
+      @RequestParam String memo,
+      @RequestParam boolean isCompleted) {
+    Checklist updatedChecklist = checklistService.updateChecklist(checkId, item, memo, isCompleted);
+    return ResponseEntity.ok(updatedChecklist);
+  }
+
+  // 체크리스트 항목 삭제
+  @DeleteMapping("/{checkId}")
+  public ResponseEntity<Void> deleteChecklist(@PathVariable Long checkId) {
+    checklistService.deleteChecklist(checkId);
+    return ResponseEntity.noContent().build();
+  }
+
+  // 준비 완료 진행률 계산
+  @GetMapping("/trip/{tripId}/completion-rate")
+  public ResponseEntity<Double> getCompletionRate(@PathVariable Long tripId) {
+    double completionRate = checklistService.calculateCompletionRate(tripId);
+    return ResponseEntity.ok(completionRate);
+  }
+}

--- a/src/main/java/daehun/trip_java/Checklist/Repository/ChecklistRepository.java
+++ b/src/main/java/daehun/trip_java/Checklist/Repository/ChecklistRepository.java
@@ -1,0 +1,10 @@
+package daehun.trip_java.Checklist.Repository;
+
+import daehun.trip_java.Checklist.domain.Checklist;
+import daehun.trip_java.Trip.domain.Trip;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChecklistRepository extends JpaRepository<Checklist, Long> {
+  List<Checklist> findByTrip(Trip trip);
+}

--- a/src/main/java/daehun/trip_java/Checklist/Service/ChecklistService.java
+++ b/src/main/java/daehun/trip_java/Checklist/Service/ChecklistService.java
@@ -1,0 +1,69 @@
+package daehun.trip_java.Checklist.Service;
+
+import daehun.trip_java.Checklist.Repository.ChecklistRepository;
+import daehun.trip_java.Checklist.domain.Checklist;
+import daehun.trip_java.Trip.domain.Trip;
+import daehun.trip_java.Trip.repository.TripRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChecklistService {
+
+  private final ChecklistRepository checklistRepository;
+  private final TripRepository tripRepository;
+
+  // 체크리스트 항목 생성
+  public Checklist createChecklist(Long tripId, String item, String memo) {
+    Trip trip = tripRepository.findById(tripId)
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 여행 ID입니다."));
+
+    Checklist checklist = new Checklist();
+    checklist.setTrip(trip);
+    checklist.setItem(item);
+    checklist.setMemo(memo);
+    checklist.setIsCompleted(false); // 초기값은 완료되지 않음
+    return checklistRepository.save(checklist);
+  }
+
+  // 특정 여행에 대한 체크리스트 조회
+  public List<Checklist> getChecklistsByTrip(Long tripId) {
+    Trip trip = tripRepository.findById(tripId)
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 여행 ID입니다."));
+    return checklistRepository.findByTrip(trip);
+  }
+
+  // 체크리스트 항목 수정
+  public Checklist updateChecklist(Long checkId, String item, String memo, boolean isCompleted) {
+    Checklist checklist = checklistRepository.findById(checkId)
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 체크리스트 ID입니다."));
+    checklist.setItem(item);
+    checklist.setMemo(memo);
+    checklist.setIsCompleted(isCompleted);
+    return checklistRepository.save(checklist);
+  }
+
+  // 체크리스트 항목 삭제
+  public void deleteChecklist(Long checkId) {
+    checklistRepository.deleteById(checkId);
+  }
+
+  // 준비 완료 진행률 계산
+  public double calculateCompletionRate(Long tripId) {
+    Trip trip = tripRepository.findById(tripId)
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 여행 ID입니다."));
+    List<Checklist> checklists = checklistRepository.findByTrip(trip);
+
+    if (checklists.isEmpty()) {
+      return 0.0;
+    }
+
+    long completedCount = checklists.stream()
+        .filter(Checklist::isCompleted)
+        .count();
+
+    return (double) completedCount / checklists.size() * 100;
+  }
+}

--- a/src/main/java/daehun/trip_java/Checklist/domain/Checklist.java
+++ b/src/main/java/daehun/trip_java/Checklist/domain/Checklist.java
@@ -1,0 +1,65 @@
+package daehun.trip_java.Checklist.domain;
+
+import daehun.trip_java.Trip.domain.Trip;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "checklist")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Checklist {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long checkId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "trip_id", nullable = false)
+  private Trip trip;
+
+  @Column(name = "item", nullable = false)
+  private String item;
+
+  @Column(name = "isCompleted", nullable = false)
+  private Boolean isCompleted = false;
+
+  @Column(name = "memo", length = 100)
+  private String memo;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    createdAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    updatedAt = LocalDateTime.now();
+  }
+
+  public Boolean isCompleted() {
+    return isCompleted;
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 체크리스트(Checklist) 기능 미구현(엔티티 설계, CRUD, 준비 완료 진행률 표시)

<br>

**TO-BE**
- Checklist 엔티티와 Trip 엔티티 간의 관계 설정 (@ManyToOne 관계 설정)
- 체크리스트 항목의 생성, 조회, 수정, 삭제 기능 구현
- 체크리스트 항목의 준비 완료 여부를 관리하고, 전체 준비 완료 진행률을 계산하는 기능 구현
- 각 체크리스트 항목에 메모를 추가할 수 있는 기능 구현

<br>

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 